### PR TITLE
s6rc.bbclass: Fix useradd packages overwrite

### DIFF
--- a/classes/s6rc.bbclass
+++ b/classes/s6rc.bbclass
@@ -7,7 +7,7 @@ FILES:${PN}:append = " ${S6RC_BASEDIR}"
 RDEPENDS:${PN}:append = " execline"
 
 inherit useradd
-USERADD_PACKAGES = "${PN}"
+USERADD_PACKAGES += "${PN}"
 USERADD_PARAM:${PN}:prepend = " --system --home ${localstatedir}/log \
                             --no-create-home --shell /bin/false \
                             --user-group logger;"


### PR DESCRIPTION
Each recipe that inherits s6rc.bbclass will create the "logger" user with useradd. The current implementation overwrites existing values of "USERADD_PACKAGES".

With this change "USERADD_PACKAGES" will be appended to ensure that the existing value persists.