### PR TITLE
Fix sysctl oneshot not allowing more than one file

### DIFF
--- a/recipes-rc/s6-init/files/sysctl.up
+++ b/recipes-rc/s6-init/files/sysctl.up
@@ -1,0 +1,12 @@
+#!/bin/execlineb -P
+
+elglob -0 FILES /etc/sysctl.d/*.conf
+
+# "elglob" splits value in as many words as there are matches for the globbing pattern
+# Concatenate all words, as "test" can only process one argument
+backtick FILES_TEST { echo $FILES }
+importas -u FILES_TEST FILES_TEST
+if -t { test "$FILES_TEST" }
+
+# Use the split value for "sysctl"
+/sbin/sysctl -q -p $FILES

--- a/recipes-rc/s6-init/s6-init.bb
+++ b/recipes-rc/s6-init/s6-init.bb
@@ -18,6 +18,7 @@ SRC_URI = "file://sysctl-printk.conf\
            file://rc-finish\
            file://rc-dynamic\
            file://s6-startstop\
+           file://sysctl.up\
            file://rc.init\
            file://rc.shutdown\
            file://rc.shutdown.final\
@@ -105,7 +106,6 @@ S6RC_ONESHOT_mount-all[up] = "mount -at nonfs,nosmbfs,noncpfs"
 S6RC_ONESHOT_mount-all[dependencies] = "mount-procsysdev mount-temp mount-devpts"
 
 S6RC_ONESHOT_sysctl[dependencies] = "mount-procsysdev"
-S6RC_ONESHOT_sysctl[up] = "elglob -0 FILES /etc/sysctl.d/*.conf if -t { test "$FILES" } /sbin/sysctl -q -p $FILES"
 
 S6RC_ONESHOT_networking[dependencies] = "ifup-lo"
 S6RC_ONESHOT_networking[up] = "/sbin/ifup -a --ignore-errors"


### PR DESCRIPTION
The "sysctl" oneshot loads additional sysctl settings from /etc/sysctl.d/*.conf. Before running the actual command to load these settings, it tests if there are any files that match the pattern. The globbing is done with "elglob" which splits the result into as many words as there are matches for the pattern. This is the required behavior when using "sysctl -p". During the test, however, an error occurs if there is more than one match, as "test" only accepts one argument.

This change concatenates the split result into one that can be tested.